### PR TITLE
DEVX-1562 Updated devcontainer as it was failing to load.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,13 +2,21 @@
 ARG VARIANT=12
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
+# yarn invalid key fix
+# https://github.com/yarnpkg/yarn/issues/7866
+# https://tickets.dominodatalab.com/hc/en-us/articles/12830637385364-Yarn-Package-invalid-key
+ENV YARNKEY=yarn-keyring.gpg
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo gpg --dearmour -o /usr/share/keyrings/$YARNKEY && \
+    echo "deb [signed-by=/usr/share/keyrings/$YARNKEY] https://dl.yarnpkg.com/debian stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+
 # Install MongoDB command line tools
-ARG MONGO_TOOLS_VERSION=4.2
-RUN curl -sSL "https://www.mongodb.org/static/pgp/server-${MONGO_TOOLS_VERSION}.asc" | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
-    && echo "deb http://repo.mongodb.org/apt/debian $(lsb_release -cs)/mongodb-org/${MONGO_TOOLS_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_TOOLS_VERSION}.list \
+ENV MONGO_VERSION 5.0
+RUN wget -qO - https://www.mongodb.org/static/pgp/server-${MONGO_VERSION}.asc | apt-key add - \
+    && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/${MONGO_VERSION} multiverse" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_VERSION}.list \
     && apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y mongodb-org-tools mongodb-org-shell \
+    && apt-get install -y mongodb-database-tools \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
 
 # Update args in docker-compose.yaml to set the UID/GID of the "node" user.
 ARG USER_UID=1000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,15 +7,15 @@
 	"service": "app",
 	"workspaceFolder": "/workspace",
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
-
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"dbaeumer.vscode-eslint",
-		"mongodb.mongodb-vscode" 
-	],
-
+	"customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": ["dbaeumer.vscode-eslint", "mongodb.mongodb-vscode", "ms-azuretools.vscode-docker"],
+			// Set *default* container specific settings.json values on container create.
+			"settings": []
+    }
+  },
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [3000, 27017],
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ A management api/interface for organizations to self-serve org membership.
 2. `cd web && npm i`
 3. `npm run start`
 
+### Troubleshooting dev container
+**Error:**
+```
+Error: Cannot find module '/home/node/.vscode-server/data/User/workspaceStorage/a99351aea6a5bd234dcb9a69463ecc7b/ms-vscode.js-debug/bootloader.js'
+Require stack:
+- internal/preload
+    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1026:15)
+    at Function.Module._load (node:internal/modules/cjs/loader:871:27)
+    at internalRequire (node:internal/modules/cjs/loader:169:19)
+    at Module._preloadModules (node:internal/modules/cjs/loader:1373:5)
+    at loadPreloadModules (node:internal/bootstrap/pre_execution:583:5)
+    at prepareMainThreadExecution (node:internal/bootstrap/pre_execution:95:3)
+    at node:internal/main/run_main_module:9:1 {
+  code: 'MODULE_NOT_FOUND',
+  requireStack: [ 'internal/preload' ]
+```
+**Solution:**
+
+* Toggle "VSCode -> View -> Command Palette -> Debug: Toggle Auto Detach" to Disabled and then Smart
+
 ## Docs
 
 Checkout out [justask.cloud](https://justask.cloud) for the app documentation.


### PR DESCRIPTION
These changes were not needed for the implementation of DEVX-1562 to remove the bcdevops organization. These changes are for local development only. They fix the dev container and docker file. The dev container was not initiating and throwing errors because it could not find deprecated packages.

