### PR TITLE
turned off admin and persist config

### DIFF
--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -1,10 +1,15 @@
+{
+	persist_config off
+	admin off
+}
+
 # Where caddy should listen
 :2015
 # Turn on the Web/file server
 file_server
 
 templates {
-        mime application/javascript
+	mime application/javascript
 }
 # The site root
 root * /opt/app-root/www
@@ -12,20 +17,20 @@ root * /opt/app-root/www
 encode zstd gzip
 
 handle /static/* {
-        header Cache-Control "max-age=31536000"
+	header Cache-Control "max-age=31536000"
 }
 
 handle {
-       header Cache-Control "no-cache, must-revalidate"
+	header Cache-Control "no-cache, must-revalidate"
 }
 
 handle /service-worker.js {
-        header Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+	header Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
 }
 
 header /service-worker.js {
-        # all static assets SHOULD be cached
-        Content-Type "text/javascript"
+	# all static assets SHOULD be cached
+	Content-Type "text/javascript"
 }
 # On OCP we should log to stdout so Prometheus can
 # slurp up the logs for human consumption.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -20,6 +20,13 @@ FROM caddy:2.10.0-alpine@sha256:e2e3a089760c453bc51c4e718342bd7032d6714f15b437db
 # Needed to use Caddy's logging format transform
 RUN caddy add-package github.com/caddyserver/transform-encoder   
 
+# From https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/images/creating-images#use-uid_create-images
+# Even though the admin and persistent config is turned off in the Caddyfile, caddy still tries to create files
+# in the data and config directories
+RUN mkdir -p /data/caddy /config/caddy && \
+    chgrp -R 0 /data /config && \
+    chmod -R g=u /data /config
+
 ## Default dir for caddy iamge
 
 RUN mkdir /opt/app-root

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -22,10 +22,10 @@ RUN caddy add-package github.com/caddyserver/transform-encoder
 
 # From https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/images/creating-images#use-uid_create-images
 # Even though the admin and persistent config is turned off in the Caddyfile, caddy still tries to create files
-# in the data and config directories
-RUN mkdir -p /data/caddy /config/caddy && \
-    chgrp -R 0 /data /config && \
-    chmod -R g=u /data /config
+# in the data directory. So give it the appropriate permissions.
+RUN mkdir -p /data/caddy && \
+    chgrp -R 0 /data && \
+    chmod -R g=u /data 
 
 ## Default dir for caddy iamge
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23-alpine3.21@sha256:86703151a18fcd06258e013073508c4afea8e19cd7ed451554221dd00aea83fc AS builder
+FROM node:23-alpine3.21@sha256:139be64e98a1374a1c49ee62b23a91f688a37a628422ff8bb9fba94185678ab3 AS builder
 
 USER 0
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,7 +21,7 @@ FROM caddy:2.10.0-alpine@sha256:e2e3a089760c453bc51c4e718342bd7032d6714f15b437db
 RUN caddy add-package github.com/caddyserver/transform-encoder   
 
 # From https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/images/creating-images#use-uid_create-images
-# Even though the admin and persistent config is turned off in the Caddyfile, caddy still tries to create files
+# Even though the admin and persistent config is turned off in the Caddyfile, caddy still creates files
 # in the data directory. So give it the appropriate permissions.
 RUN mkdir -p /data/caddy && \
     chgrp -R 0 /data && \


### PR DESCRIPTION
This PR does the following:

- Turns off the admin console and the persist config options in the caddy server.
- Add permissions for the data directory
- Updates the node node:23-alpine3.21 pinned version

The permission changes are to fix these warning messages in the caddy log file when running on OpenShift:

```shell
{"level":"warn","ts":1748533567.4819305,"logger":"tls","msg":"unable to get instance ID; storage clean stamps will be incomplete","error":"open /data/caddy/instance.uuid: permission denied"}
{"level":"error","ts":1748533567.4819746,"logger":"tls","msg":"could not clean default/global storage","error":"unable to acquire storage_clean lock: creating lock file: open /data/caddy/locks/storage_clean.lock: no such file or directory"}
```
